### PR TITLE
fix: remove unused cases in switch

### DIFF
--- a/lab/L5 (parser)/Parser.java
+++ b/lab/L5 (parser)/Parser.java
@@ -60,11 +60,6 @@ public class Parser {
                 term();
                 exprp();
                 break;
-
-            case ')':
-            case Tag.EOF:
-                break;
-
         }
     }
 
@@ -90,12 +85,6 @@ public class Parser {
                 match(Token.div.tag);
                 fact();
                 termp();
-                break;
-            
-            case '+':
-            case '-':
-            case ')':
-            case Tag.EOF:
                 break;
         }
     }


### PR DESCRIPTION
Remove unused cases in switch. 
Cases that reach only the break statement are not useful to parse text.